### PR TITLE
Utilizing the TConfiguration setting, introduced in Apache Thrift 0.14.0

### DIFF
--- a/src/main/java/org/glassfish/grizzly/thrift/AbstractTGrizzlyTransport.java
+++ b/src/main/java/org/glassfish/grizzly/thrift/AbstractTGrizzlyTransport.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2011, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -19,7 +20,7 @@ package org.glassfish.grizzly.thrift;
 import java.io.IOException;
 
 import org.apache.thrift.TConfiguration;
-import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TEndpointTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.glassfish.grizzly.Buffer;
 import org.glassfish.grizzly.utils.BufferOutputStream;
@@ -31,7 +32,15 @@ import org.glassfish.grizzly.utils.BufferOutputStream;
  *
  * @author Bongjae Chang
  */
-public abstract class AbstractTGrizzlyTransport extends TTransport {
+public abstract class AbstractTGrizzlyTransport extends TEndpointTransport {
+
+    public AbstractTGrizzlyTransport() throws TTransportException {
+        super(null);
+    }
+
+    public AbstractTGrizzlyTransport(final TConfiguration config) throws TTransportException {
+        super(config);
+    }
 
     @Override
     public void open() throws TTransportException {
@@ -39,10 +48,12 @@ public abstract class AbstractTGrizzlyTransport extends TTransport {
 
     @Override
     public int read(byte[] buf, int off, int len) throws TTransportException {
+        checkReadBytesAvailable((long) len);
         final Buffer input = getInputBuffer();
         final int readableBytes = input.remaining();
         final int bytesToRead = len > readableBytes ? readableBytes : len;
         input.get(buf, off, bytesToRead);
+        countConsumedMessageBytes((long) bytesToRead);
         return bytesToRead;
     }
 
@@ -60,21 +71,6 @@ public abstract class AbstractTGrizzlyTransport extends TTransport {
 
     @Override
     public abstract void flush() throws TTransportException;
-
-    @Override
-    public TConfiguration getConfiguration() {
-        return null;
-    }
-
-    @Override
-    public void updateKnownMessageSize(long l) throws TTransportException {
-
-    }
-
-    @Override
-    public void checkReadBytesAvailable(long l) throws TTransportException {
-
-    }
 
     protected abstract Buffer getInputBuffer() throws TTransportException;
 

--- a/src/main/java/org/glassfish/grizzly/thrift/TGrizzlyClientTransport.java
+++ b/src/main/java/org/glassfish/grizzly/thrift/TGrizzlyClientTransport.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2011, 2017 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -24,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.thrift.TConfiguration;
 import org.apache.thrift.transport.TTransportException;
 import org.glassfish.grizzly.Buffer;
 import org.glassfish.grizzly.Connection;
@@ -72,6 +74,10 @@ public class TGrizzlyClientTransport extends AbstractTGrizzlyTransport {
     }
 
     public static TGrizzlyClientTransport create(final Connection connection, final long readTimeoutMillis, final long writeTimeoutMillis) {
+        return create(connection, readTimeoutMillis, writeTimeoutMillis, null);
+    }
+
+    public static TGrizzlyClientTransport create(final Connection connection, final long readTimeoutMillis, final long writeTimeoutMillis, final TConfiguration config) {
         if (connection == null) {
             throw new IllegalStateException("connection should not be null.");
         }
@@ -89,10 +95,15 @@ public class TGrizzlyClientTransport extends AbstractTGrizzlyTransport {
         if (thriftClientFilter == null) {
             throw new IllegalStateException("thriftClientFilter should not be null.");
         }
-        return new TGrizzlyClientTransport(connection, readTimeoutMillis, writeTimeoutMillis);
+        try {
+            return new TGrizzlyClientTransport(connection, readTimeoutMillis, writeTimeoutMillis, config);
+        } catch (TTransportException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
-    private TGrizzlyClientTransport(final Connection connection, final long readTimeoutMillis, final long writeTimeoutMillis) {
+    private TGrizzlyClientTransport(final Connection connection, final long readTimeoutMillis, final long writeTimeoutMillis, final TConfiguration config) throws TTransportException {
+        super(config);
         this.connection = connection;
         this.inputBuffersQueue = new LinkedTransferQueue<>();
         inputBuffersQueueAttribute.set(connection, this.inputBuffersQueue);
@@ -155,6 +166,8 @@ public class TGrizzlyClientTransport extends AbstractTGrizzlyTransport {
             throw new TTransportException(ee);
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
+        } finally {
+            resetConsumedMessageSize(-1L);
         }
     }
 

--- a/src/main/java/org/glassfish/grizzly/thrift/TGrizzlyServerTransport.java
+++ b/src/main/java/org/glassfish/grizzly/thrift/TGrizzlyServerTransport.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2011, 2017 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,6 +17,7 @@
 
 package org.glassfish.grizzly.thrift;
 
+import org.apache.thrift.TConfiguration;
 import org.apache.thrift.transport.TTransportException;
 import org.glassfish.grizzly.Buffer;
 import org.glassfish.grizzly.utils.BufferOutputStream;
@@ -33,7 +35,8 @@ public class TGrizzlyServerTransport extends AbstractTGrizzlyTransport {
     private final Buffer input;
     private final BufferOutputStream outputStream;
 
-    public TGrizzlyServerTransport(final Buffer input, final BufferOutputStream outputStream) {
+    public TGrizzlyServerTransport(final Buffer input, final BufferOutputStream outputStream, final TConfiguration config) throws TTransportException {
+        super(config);
         this.input = input;
         this.outputStream = outputStream;
     }
@@ -49,6 +52,7 @@ public class TGrizzlyServerTransport extends AbstractTGrizzlyTransport {
 
     @Override
     public void flush() throws TTransportException {
+        resetConsumedMessageSize(-1L);
     }
 
     @Override

--- a/src/main/java/org/glassfish/grizzly/thrift/ThriftFrameFilter.java
+++ b/src/main/java/org/glassfish/grizzly/thrift/ThriftFrameFilter.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2011, 2017 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -18,6 +19,7 @@ package org.glassfish.grizzly.thrift;
 
 import java.io.IOException;
 
+import org.apache.thrift.TConfiguration;
 import org.glassfish.grizzly.Buffer;
 import org.glassfish.grizzly.Connection;
 import org.glassfish.grizzly.Grizzly;
@@ -40,18 +42,18 @@ import org.glassfish.grizzly.memory.MemoryManager;
 public class ThriftFrameFilter extends BaseFilter {
 
     private static final int THRIFT_FRAME_HEADER_LENGTH = 4;
-    private static final int DEFAULT_DEFAULT_MAX_THRIFT_FRAME_LENGTH = 512 * 1024;
+    private static final int DEFAULT_MAX_THRIFT_FRAME_LENGTH = 512 * 1024;
     private final int maxFrameLength;
 
     private final Attribute<Integer> lengthAttribute = Grizzly.DEFAULT_ATTRIBUTE_BUILDER.createAttribute("ThriftFilter.FrameSize");
 
     public ThriftFrameFilter() {
-        this(DEFAULT_DEFAULT_MAX_THRIFT_FRAME_LENGTH);
+        this(TConfiguration.DEFAULT_MAX_FRAME_SIZE);
     }
 
     public ThriftFrameFilter(final int maxFrameLength) {
-        if (maxFrameLength < DEFAULT_DEFAULT_MAX_THRIFT_FRAME_LENGTH) {
-            this.maxFrameLength = DEFAULT_DEFAULT_MAX_THRIFT_FRAME_LENGTH;
+        if (maxFrameLength < DEFAULT_MAX_THRIFT_FRAME_LENGTH) {
+            this.maxFrameLength = DEFAULT_MAX_THRIFT_FRAME_LENGTH;
         } else {
             this.maxFrameLength = maxFrameLength;
         }

--- a/src/main/java/org/glassfish/grizzly/thrift/ThriftServerFilter.java
+++ b/src/main/java/org/glassfish/grizzly/thrift/ThriftServerFilter.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2011, 2017 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -18,12 +19,14 @@ package org.glassfish.grizzly.thrift;
 
 import java.io.IOException;
 
+import org.apache.thrift.TConfiguration;
 import org.apache.thrift.TException;
 import org.apache.thrift.TProcessor;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.protocol.TProtocolFactory;
 import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
 import org.glassfish.grizzly.Buffer;
 import org.glassfish.grizzly.filterchain.BaseFilter;
 import org.glassfish.grizzly.filterchain.FilterChainContext;
@@ -63,26 +66,44 @@ public class ThriftServerFilter extends BaseFilter {
 
     private final TProcessor processor;
     private final TProtocolFactory protocolFactory;
+    private final TConfiguration config;
     private final int responseSize;
 
     public ThriftServerFilter(final TProcessor processor) {
-        this(processor, new TBinaryProtocol.Factory(), THRIFT_DEFAULT_RESPONSE_BUFFER_SIZE);
+        this(processor, new TBinaryProtocol.Factory(), null, THRIFT_DEFAULT_RESPONSE_BUFFER_SIZE);
     }
 
     public ThriftServerFilter(final TProcessor processor, final TProtocolFactory protocolFactory) {
-        this(processor, protocolFactory, THRIFT_DEFAULT_RESPONSE_BUFFER_SIZE);
+        this(processor, protocolFactory, null, THRIFT_DEFAULT_RESPONSE_BUFFER_SIZE);
     }
 
     public ThriftServerFilter(final TProcessor processor, final int responseSize) {
-        this(processor, new TBinaryProtocol.Factory(), responseSize);
+        this(processor, new TBinaryProtocol.Factory(), null, responseSize);
+    }
+
+    public ThriftServerFilter(final TProcessor processor, final TConfiguration config) {
+        this(processor, new TBinaryProtocol.Factory(), config, THRIFT_DEFAULT_RESPONSE_BUFFER_SIZE);
     }
 
     public ThriftServerFilter(final TProcessor processor, final TProtocolFactory protocolFactory, final int responseSize) {
+        this(processor, protocolFactory, null, responseSize);
+    }
+
+    public ThriftServerFilter(final TProcessor processor, final TProtocolFactory protocolFactory, final TConfiguration config) {
+        this(processor, protocolFactory, config, THRIFT_DEFAULT_RESPONSE_BUFFER_SIZE);
+    }
+
+    public ThriftServerFilter(final TProcessor processor, final TProtocolFactory protocolFactory, final TConfiguration config, final int responseSize) {
         this.processor = processor;
         if (protocolFactory == null) {
             this.protocolFactory = new TBinaryProtocol.Factory();
         } else {
             this.protocolFactory = protocolFactory;
+        }
+        if (config == null) {
+            this.config = TConfiguration.DEFAULT;
+        } else {
+            this.config = config;
         }
         if (responseSize < THRIFT_DEFAULT_RESPONSE_BUFFER_SIZE) {
             this.responseSize = THRIFT_DEFAULT_RESPONSE_BUFFER_SIZE;
@@ -106,7 +127,14 @@ public class ThriftServerFilter extends BaseFilter {
 
         final MemoryManager memoryManager = ctx.getMemoryManager();
         final BufferOutputStream outputStream = new BufferOutputStream(memoryManager, memoryManager.allocate(responseSize));
-        final TTransport ttransport = new TGrizzlyServerTransport(input, outputStream);
+        final TTransport ttransport;
+        try {
+            ttransport = new TGrizzlyServerTransport(input, outputStream, config);
+        } catch (TTransportException tte) {
+            input.dispose();
+            outputStream.getBuffer().dispose();
+            throw new IOException(tte);
+        }
         final TProtocol protocol = protocolFactory.getProtocol(ttransport);
         try {
             processor.process(protocol, protocol);

--- a/src/main/java/org/glassfish/grizzly/thrift/client/GrizzlyThriftClient.java
+++ b/src/main/java/org/glassfish/grizzly/thrift/client/GrizzlyThriftClient.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -36,6 +37,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.apache.thrift.TConfiguration;
 import org.apache.thrift.TServiceClient;
 import org.apache.thrift.TServiceClientFactory;
 import org.apache.thrift.protocol.TBinaryProtocol;
@@ -160,6 +162,8 @@ public class GrizzlyThriftClient<T extends TServiceClient> implements ThriftClie
 
     private final TransferProtocols transferProtocol;
     private final int maxThriftFrameLength;
+    private final int maxThriftMessageLength;
+    private final TConfiguration thriftConfig;
     private final String httpUriPath;
     private Map<String, String> httpHeaders;
     private final Processor processor;
@@ -177,6 +181,10 @@ public class GrizzlyThriftClient<T extends TServiceClient> implements ThriftClie
         this.retainLastServer = builder.retainLastServer;
 
         this.maxThriftFrameLength = builder.maxThriftFrameLength;
+        this.maxThriftMessageLength = builder.maxThriftMessageLength;
+        this.thriftConfig =
+                TConfiguration.custom().setMaxFrameSize(maxThriftFrameLength).setMaxMessageSize(maxThriftMessageLength)
+                              .build();
         this.transferProtocol = builder.transferProtocol;
         this.httpUriPath = builder.httpUriPath;
         this.httpHeaders = builder.httpHeaders;
@@ -247,7 +255,7 @@ public class GrizzlyThriftClient<T extends TServiceClient> implements ThriftClie
                         if (connection != null) {
                             connectionPoolAttribute.set(connection, connectionPool);
                             final TGrizzlyClientTransport ttransport = TGrizzlyClientTransport.create(connection, responseTimeoutInMillis,
-                                    writeTimeoutInMillis);
+                                    writeTimeoutInMillis, thriftConfig);
                             final TProtocol protocol;
                             if (thriftProtocol == ThriftProtocols.BINARY) {
                                 protocol = new TBinaryProtocol(ttransport);
@@ -679,12 +687,12 @@ public class GrizzlyThriftClient<T extends TServiceClient> implements ThriftClie
         return true;
     }
 
-    private boolean validateConnection(final Connection connection) {
+    private boolean validateConnection(final Connection connection) throws TTransportException {
         if (connection == null) {
             return false;
         }
         final TGrizzlyClientTransport ttransport = TGrizzlyClientTransport.create(connection, responseTimeoutInMillis,
-                writeTimeoutInMillis);
+                writeTimeoutInMillis, thriftConfig);
         final TProtocol protocol;
         if (thriftProtocol == ThriftProtocols.BINARY) {
             protocol = new TBinaryProtocol(ttransport);
@@ -846,6 +854,7 @@ public class GrizzlyThriftClient<T extends TServiceClient> implements ThriftClie
 
         private final ZKClient zkClient;
         private int maxThriftFrameLength;
+        private int maxThriftMessageLength;
 
         private String httpUriPath = "/";
         private Map<String, String> httpHeaders;
@@ -858,6 +867,7 @@ public class GrizzlyThriftClient<T extends TServiceClient> implements ThriftClie
             this.clientFactory = clientFactory;
             this.zkClient = manager.getZkClient();
             this.maxThriftFrameLength = manager.getMaxThriftFrameLength();
+            this.maxThriftMessageLength = manager.getMaxThriftMessageLength();
         }
 
         /**
@@ -1086,6 +1096,17 @@ public class GrizzlyThriftClient<T extends TServiceClient> implements ThriftClie
             return this;
         }
 
+        /**
+         * Set the max length of thrift message
+         *
+         * @param maxThriftMessageLength max message length
+         * @return this builder
+         */
+        public Builder maxThriftMessageLength(final int maxThriftMessageLength) {
+            this.maxThriftMessageLength = maxThriftMessageLength;
+            return this;
+        }
+
         public Builder<T> httpUriPath(final String httpUriPath) {
             if (httpUriPath == null || httpUriPath.isEmpty()) {
                 return this;
@@ -1137,6 +1158,7 @@ public class GrizzlyThriftClient<T extends TServiceClient> implements ThriftClie
         sb.append(", zooKeeperServerListPath='").append(zooKeeperServerListPath).append('\'');
         sb.append(", transferProtocol=").append(transferProtocol);
         sb.append(", maxThriftFrameLength=").append(maxThriftFrameLength);
+        sb.append(", maxThriftMessageLength=").append(maxThriftMessageLength);
         sb.append(", httpUriPath='").append(httpUriPath).append('\'');
         sb.append('}');
         return sb.toString();

--- a/src/main/java/org/glassfish/grizzly/thrift/client/GrizzlyThriftClientManager.java
+++ b/src/main/java/org/glassfish/grizzly/thrift/client/GrizzlyThriftClientManager.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -23,6 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.apache.thrift.TConfiguration;
 import org.apache.thrift.TServiceClient;
 import org.apache.thrift.TServiceClientFactory;
 import org.glassfish.grizzly.Grizzly;
@@ -62,9 +64,11 @@ public class GrizzlyThriftClientManager implements ThriftClientManager {
 
     private ZKClient zkClient;
     private final int maxThriftFrameLength;
+    private final int maxThriftMessageLength;
 
     private GrizzlyThriftClientManager(final Builder builder) {
         this.maxThriftFrameLength = builder.maxThriftFrameLength;
+        this.maxThriftMessageLength = builder.maxThriftMessageLength;
         TCPNIOTransport transportLocal = builder.transport;
         if (transportLocal == null) {
             isExternalTransport = false;
@@ -206,6 +210,10 @@ public class GrizzlyThriftClientManager implements ThriftClientManager {
         return maxThriftFrameLength;
     }
 
+    int getMaxThriftMessageLength() {
+        return maxThriftMessageLength;
+    }
+
     public static class Builder {
 
         private TCPNIOTransport transport;
@@ -215,7 +223,8 @@ public class GrizzlyThriftClientManager implements ThriftClientManager {
         private IOStrategy ioStrategy = SameThreadIOStrategy.getInstance();
         private boolean blocking = false;
         private ExecutorService workerThreadPool;
-        private int maxThriftFrameLength = 1024 * 1024; // 1M
+        private int maxThriftFrameLength = TConfiguration.DEFAULT_MAX_FRAME_SIZE;
+        private int maxThriftMessageLength = TConfiguration.DEFAULT_MAX_MESSAGE_SIZE;
 
         // zookeeper config
         private ZooKeeperConfig zooKeeperConfig;
@@ -325,6 +334,17 @@ public class GrizzlyThriftClientManager implements ThriftClientManager {
          */
         public Builder maxThriftFrameLength(final int maxThriftFrameLength) {
             this.maxThriftFrameLength = maxThriftFrameLength;
+            return this;
+        }
+
+        /**
+         * Set the max length of thrift message
+         *
+         * @param maxThriftMessageLength max message length
+         * @return this builder
+         */
+        public Builder maxThriftMessageLength(final int maxThriftMessageLength) {
+            this.maxThriftMessageLength = maxThriftMessageLength;
             return this;
         }
 

--- a/src/main/java/org/glassfish/grizzly/thrift/http/ThriftHttpHandler.java
+++ b/src/main/java/org/glassfish/grizzly/thrift/http/ThriftHttpHandler.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2014, 2017 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -18,6 +19,7 @@ package org.glassfish.grizzly.thrift.http;
 
 import java.io.IOException;
 
+import org.apache.thrift.TConfiguration;
 import org.apache.thrift.TException;
 import org.apache.thrift.TProcessor;
 import org.apache.thrift.protocol.TBinaryProtocol;
@@ -62,26 +64,40 @@ public class ThriftHttpHandler extends HttpHandler {
 
     private final TProcessor processor;
     private final TProtocolFactory protocolFactory;
+    private final TConfiguration config;
     private final int responseSize;
 
     public ThriftHttpHandler(final TProcessor processor) {
-        this(processor, new TBinaryProtocol.Factory(), THRIFT_DEFAULT_RESPONSE_BUFFER_SIZE);
+        this(processor, new TBinaryProtocol.Factory(), null, THRIFT_DEFAULT_RESPONSE_BUFFER_SIZE);
     }
 
     public ThriftHttpHandler(final TProcessor processor, final TProtocolFactory protocolFactory) {
-        this(processor, protocolFactory, THRIFT_DEFAULT_RESPONSE_BUFFER_SIZE);
+        this(processor, protocolFactory, null, THRIFT_DEFAULT_RESPONSE_BUFFER_SIZE);
+    }
+
+    public ThriftHttpHandler(final TProcessor processor, final TProtocolFactory protocolFactory, final TConfiguration config) {
+        this(processor, protocolFactory, config, THRIFT_DEFAULT_RESPONSE_BUFFER_SIZE);
     }
 
     public ThriftHttpHandler(final TProcessor processor, final int responseSize) {
-        this(processor, new TBinaryProtocol.Factory(), responseSize);
+        this(processor, new TBinaryProtocol.Factory(), null, responseSize);
     }
 
     public ThriftHttpHandler(final TProcessor processor, final TProtocolFactory protocolFactory, final int responseSize) {
+        this(processor, protocolFactory, null, responseSize);
+    }
+
+    public ThriftHttpHandler(final TProcessor processor, final TProtocolFactory protocolFactory, final TConfiguration config, final int responseSize) {
         this.processor = processor;
         if (protocolFactory == null) {
             this.protocolFactory = new TBinaryProtocol.Factory();
         } else {
             this.protocolFactory = protocolFactory;
+        }
+        if (config == null) {
+            this.config = TConfiguration.DEFAULT;
+        } else {
+            this.config = config;
         }
         if (responseSize < THRIFT_DEFAULT_RESPONSE_BUFFER_SIZE) {
             this.responseSize = THRIFT_DEFAULT_RESPONSE_BUFFER_SIZE;
@@ -106,7 +122,7 @@ public class ThriftHttpHandler extends HttpHandler {
 
         final MemoryManager memoryManager = request.getContext().getMemoryManager();
         final BufferOutputStream outputStream = new BufferOutputStream(memoryManager, memoryManager.allocate(responseSize));
-        final TTransport ttransport = new TGrizzlyServerTransport(inputBuffer, outputStream);
+        final TTransport ttransport = new TGrizzlyServerTransport(inputBuffer, outputStream, config);
         final TProtocol protocol = protocolFactory.getProtocol(ttransport);
         try {
             processor.process(protocol, protocol);


### PR DESCRIPTION
+ `TConfiguration`: https://github.com/apache/thrift/blob/master/doc/specs/thrift-tconfiguration.md
+ Additionally, the `maxThriftMessageLength` setting is introduced to provide the ability to limit the maximum size of (received) messages.